### PR TITLE
pycodestyle voorbeeld command gecorrigeerd

### DIFF
--- a/onderwerp/00 intro/pycodestyle/index.md
+++ b/onderwerp/00 intro/pycodestyle/index.md
@@ -2,7 +2,7 @@
 
 Voor de opdrachten in deze cursus wordt een style checker gebruikt: `pycodestyle`. Deze checkt of je code aan bepaalde style regels voldoet en zal feedback geven als er iets nog niet helemaal klopt. Je kan `pycodestyle` als volgt draaien:
 
-    `pycodestyle --select=E101,E112,E113,E115,E116,E117,E501,E502,W505,W291 --max-line-length=99 --max-doc-length=79 <bestandsnaam.py>`
+    pycodestyle --select=E101,E112,E113,E115,E116,E117,E501,E502,W505,W291 --max-line-length=99 --max-doc-length=79 <bestandsnaam.py>
 
 Lange regel he? Dit is wat de geselecteerde errors en waarschuwingen betekenen:
 

--- a/onderwerp/00 intro/pycodestyle/index.md
+++ b/onderwerp/00 intro/pycodestyle/index.md
@@ -2,7 +2,7 @@
 
 Voor de opdrachten in deze cursus wordt een style checker gebruikt: `pycodestyle`. Deze checkt of je code aan bepaalde style regels voldoet en zal feedback geven als er iets nog niet helemaal klopt. Je kan `pycodestyle` als volgt draaien:
 
-    pycodestyle --select=E101,E112,E113,E115,E116,E117,E501,E502,W505,W291 --max-line-length=99 --max-doc-length=79 <bestandsnaam.py>
+    pycodestyle --select=E101,E112,E113,E115,E116,E117,E501,E502,W505,W291 --max-line-length=99 --max-doc-length=79 
 
 Lange regel he? Dit is wat de geselecteerde errors en waarschuwingen betekenen:
 

--- a/onderwerp/00 intro/pycodestyle/index.md
+++ b/onderwerp/00 intro/pycodestyle/index.md
@@ -2,7 +2,7 @@
 
 Voor de opdrachten in deze cursus wordt een style checker gebruikt: `pycodestyle`. Deze checkt of je code aan bepaalde style regels voldoet en zal feedback geven als er iets nog niet helemaal klopt. Je kan `pycodestyle` als volgt draaien:
 
-    pycodestyle --select=E101,E112,E113,E115,E116,E117,E501,E502,W505,W291 --max-line-length=99 --max-doc-length=79`
+    `pycodestyle --select=E101,E112,E113,E115,E116,E117,E501,E502,W505,W291 --max-line-length=99 --max-doc-length=79 <bestandsnaam.py>`
 
 Lange regel he? Dit is wat de geselecteerde errors en waarschuwingen betekenen:
 

--- a/onderwerp/00 intro/pycodestyle/index.md
+++ b/onderwerp/00 intro/pycodestyle/index.md
@@ -2,7 +2,7 @@
 
 Voor de opdrachten in deze cursus wordt een style checker gebruikt: `pycodestyle`. Deze checkt of je code aan bepaalde style regels voldoet en zal feedback geven als er iets nog niet helemaal klopt. Je kan `pycodestyle` als volgt draaien:
 
-    pycodestyle --select=E101,E112,E113,E115,E116,E117,E501,E502,W505,W291 --max-line-length=99 --max-doc-length=79 
+    pycodestyle --select=E101,E112,E113,E115,E116,E117,E501,E502,W505,W291 --max-line-length=99 --max-doc-length=79 bestandsnaam.py
 
 Lange regel he? Dit is wat de geselecteerde errors en waarschuwingen betekenen:
 


### PR DESCRIPTION
Stond een overbodige " ` " aan het einde van voorbeeld command & voorbeeld input bestand toegevoegd.